### PR TITLE
Use latest Rails 3 router syntax

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do |map|
   namespace 'oauth2' do
     resources :authorizations, :only => :create
   end
-  match 'oauth2/authorize', :to => 'oauth2/authorizations#new'
-  post 'oauth2/token', :to => proc { |env| TokenEndpoint.new.call(env) }
+
+  match 'oauth2/authorize' => 'oauth2/authorizations#new'
+  post 'oauth2/token' => TokenEndpoint.new
 end


### PR DESCRIPTION
I've had a few deprecation warnings regarding the router syntax used. The use of `:to => path` is going to be removed in 3.1 I believe. The preferred syntax is simpler:

``` ruby
post '/oauth/authorize` => 'oauth/authorizations#create'
```

I'm assuming TokenEndpoint.new responds to `#call` and returns something like `[status, headers, body]`. If it's effectively a Rack app then Rails 3 will call it just fine. If not the lambda may still be required, or of course TokenEndpoint could be refactored to respond in a way that Rails/Rack can understand.

No tests for this. Perhaps you'd be interested in getting some cucumber features in here? I'd be happy to write a few.
