### PR TITLE
Websafe tokens

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -9,7 +9,7 @@ class Client < ActiveRecord::Base
   private
 
   def setup
-    self.identifier = ActiveSupport::SecureRandom.base64(16)
-    self.secret = ActiveSupport::SecureRandom.base64
+    self.identifier = ActiveSupport::SecureRandom.base64(16).tr('+/', '-_').tr('=', '')
+    self.secret = ActiveSupport::SecureRandom.base64.tr('+/', '-_').tr('=', '')
   end
 end

--- a/lib/expirable_token.rb
+++ b/lib/expirable_token.rb
@@ -30,7 +30,7 @@ module ExpirableToken
   private
 
   def setup
-    self.token = ActiveSupport::SecureRandom.base64(16)
+    self.token = ActiveSupport::SecureRandom.base64(16).tr('+/', '-_').tr('=', '')
     self.expires_at ||= self.default_lifetime.from_now
   end
 end


### PR DESCRIPTION
I am trying to get up to grabs with devise_oath2_providable, and noticed that the tokens are not web safe. This patch changes this, making it simpler to play around and test. The default identifier is shortened as well, but that is not really the point of the patch.
