### PR TITLE
devise authentication_keys functionality

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 require 'token_endpoint'
-Rails.application.routes.draw do |map|
+Rails.application.routes.draw do
   namespace 'oauth2' do
     resources :authorizations, :only => :create
   end

--- a/lib/token_endpoint.rb
+++ b/lib/token_endpoint.rb
@@ -37,7 +37,7 @@ class TokenEndpoint
       mapping.to.authentication_keys.each do |key|
         conditions[key] = req.env["rack.request.form_hash"][key.to_s]
       end
-      conditions[:email] = req.username
+      conditions[mapping.to.authentication_keys.first] = req.username
       resource = mapping.to.find_for_authentication(conditions)
       raise InvalidGrantType.new('user not found') unless resource
       raise InvalidGrantType.new('user does not support password authentication') unless resource.respond_to?(:valid_password?)

--- a/spec/rails_app/Gemfile
+++ b/spec/rails_app/Gemfile
@@ -4,7 +4,8 @@ gem 'rails', '3.0.7'
 gem 'rspec-rails', '2.6.0'
 gem 'devise_oauth2_providable', :path => '../../'
 gem 'shoulda-matchers', '1.0.0.beta2'
-gem 'ruby-debug'
+# gem 'ruby-debug'
+gem 'rake', '0.8.7'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'

--- a/spec/rails_app/app/models/user.rb
+++ b/spec/rails_app/app/models/user.rb
@@ -1,3 +1,13 @@
 class User < ActiveRecord::Base
   devise :database_authenticatable, :oauth2_providable
+  
+  
+  def self.find_for_authentication(conditions)
+    user = find(:first, :readonly => false, :conditions => conditions)
+    return user
+  end
+  
+  def self.add_authentication_keys
+    devise :authentication_keys => [:email, :pet]
+  end
 end

--- a/spec/rails_app/db/migrate/20110523015635_add_pet_column_to_users.rb
+++ b/spec/rails_app/db/migrate/20110523015635_add_pet_column_to_users.rb
@@ -1,0 +1,9 @@
+class AddPetColumnToUsers < ActiveRecord::Migration
+  def self.up
+    add_column :users, :pet, :string
+  end
+
+  def self.down
+    remove_column :users, :pet
+  end
+end

--- a/spec/rails_app/db/schema.rb
+++ b/spec/rails_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110511210926) do
+ActiveRecord::Schema.define(:version => 20110523015635) do
 
   create_table "access_tokens", :force => true do |t|
     t.integer  "user_id"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(:version => 20110511210926) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "pet"
   end
 
 end

--- a/spec/rails_app/spec/integration/token_endpoint_spec.rb
+++ b/spec/rails_app/spec/integration/token_endpoint_spec.rb
@@ -33,7 +33,7 @@ describe TokenEndpoint do
   describe 'password grant type' do
     context 'with valid params' do
       before do
-        @user = User.create! :email => 'ryan@socialcast.com', :name => 'ryan sonnek', :password => 'test'
+        @user = User.create! :email => 'ryan@socialcast.com', :name => 'ryan sonnek', :password => 'test', :pet => "bailey"
         @client = Client.create! :name => 'example', :redirect_uri => 'http://localhost', :website => 'http://localhost'
 
         params = {
@@ -80,7 +80,62 @@ describe TokenEndpoint do
           :error_description => "The provided access grant is invalid, expired, or revoked (e.g. invalid assertion, expired authorization token, bad end-user password credentials, or mismatching authorization code and redirection URI).",
           :error => "invalid_grant"
         }
-        response.body.should == expected.to_json
+        JSON.parse(response.body).should == JSON.parse(expected.to_json)
+      end
+    end
+    context 'with extra params for authentication_keys' do
+      before do
+        @user = User.create! :email => 'ryan@socialcast.com', :name => 'ryan sonnek', :password => 'test', :pet => 'fluffy'
+        User.add_authentication_keys
+        @client = Client.create! :name => 'example', :redirect_uri => 'http://localhost', :website => 'http://localhost'
+
+        params = {
+          :grant_type => 'password',
+          :client_id => @client.identifier,
+          :client_secret => @client.secret,
+          :username => @user.email,
+          :password => 'test',
+          :pet => 'fluffy'
+        }
+
+        post '/oauth2/token', params
+      end
+      it { response.code.to_i.should == 200 }
+      it 'returns json' do
+        token = AccessToken.last
+        refresh_token = RefreshToken.last
+        expected = {
+          :token_type => 'bearer',
+          :expires_in => 899,
+          :refresh_token => refresh_token.token,
+          :access_token => token.token
+        }
+        JSON.parse(response.body).should == JSON.parse(expected.to_json)
+      end
+    end
+    context 'with invalid params for authentication_keys' do
+      before do
+        @user = User.create! :email => 'ryan@socialcast.com', :name => 'ryan sonnek', :password => 'test', :pet => 'fluffy'
+        @client = Client.create! :name => 'example', :redirect_uri => 'http://localhost', :website => 'http://localhost'
+
+        params = {
+          :grant_type => 'password',
+          :client_id => @client.identifier,
+          :client_secret => @client.secret,
+          :username => @user.email,
+          :password => 'bar',
+          :pet => 'cotton tail'
+        }
+
+        post '/oauth2/token', params
+      end
+      it { response.code.to_i.should == 400 }
+      it 'returns json' do
+        expected = {
+          :error_description => "The provided access grant is invalid, expired, or revoked (e.g. invalid assertion, expired authorization token, bad end-user password credentials, or mismatching authorization code and redirection URI).",
+          :error => "invalid_grant"
+        }
+        JSON.parse(response.body).should == JSON.parse(expected.to_json)
       end
     end
   end

--- a/spec/rails_app/spec/integration/token_endpoint_spec.rb
+++ b/spec/rails_app/spec/integration/token_endpoint_spec.rb
@@ -26,7 +26,7 @@ describe TokenEndpoint do
           :refresh_token => refresh_token.token,
           :access_token => token.token
         }
-        response.body.should == expected.to_json
+        JSON.parse(response.body).should == JSON.parse(expected.to_json)
       end
     end
   end
@@ -56,7 +56,7 @@ describe TokenEndpoint do
           :refresh_token => refresh_token.token,
           :access_token => token.token
         }
-        response.body.should == expected.to_json
+        JSON.parse(response.body).should == JSON.parse(expected.to_json)
       end
     end
     context 'with invalid params' do


### PR DESCRIPTION
I updated routes and gemfile to be compatible with rails 3.1 and ruby 1.9.2
The integration tests were failing because it was comparing strings, which weren't the same, but had the same data.  So I converted them back to JSON objects for comparison.
Added functionality to map params passed in to devise authentication_keys.
