### PR TITLE
Bugfix: use :client instead of :client_id for assignment of full AR model

### DIFF
--- a/app/controllers/oauth2/authorizations_controller.rb
+++ b/app/controllers/oauth2/authorizations_controller.rb
@@ -35,10 +35,10 @@ class Oauth2::AuthorizationsController < ApplicationController
         if params[:approve].present?
           case req.response_type
           when :code
-            authorization_code = current_user.authorization_codes.create(:client_id => @client, :redirect_uri => @redirect_uri)
+            authorization_code = current_user.authorization_codes.create(:client => @client, :redirect_uri => @redirect_uri)
             res.code = authorization_code.token
           when :token
-            access_token = current_user.access_tokens.create(:client_id => @client).token
+            access_token = current_user.access_tokens.create(:client => @client).token
             bearer_token = Rack::OAuth2::AccessToken::Bearer.new(:access_token => access_token)
             res.access_token = bearer_token
           end


### PR DESCRIPTION
Bugfix: under some circumstances, the authorization_code created ended up with a client_id of 1, instead of the correct client ID
