### PR TITLE
Added missing devise module to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ class User
   # if supporting Resource Owner Password Credentials Grant Type
   devise :oauth2_providable, 
     :oauth2_password_grantable,
-    :oauth2_refresh_token_grantable
+    :oauth2_refresh_token_grantable,
+    :oauth2_authorization_code_grantable
 end
 ```
 


### PR DESCRIPTION
Added missing devise module to setup instructions. 

With that added, I'm no longer running into Issue #13. I stumbled upon this in the spec/rails_app configuration and figured it must be required.
