### PR TITLE
spec_helper improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ log
 *.log
 *.sqlite3
 .rvmrc
+.rspec

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tmp
 log
 *.log
 *.sqlite3
+.rvmrc

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,0 @@
---colour
---format documentation
---backtrace

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use ree-1.8.7-2011.03@devise_oauth2_providable --create

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,13 @@
-require 'bundler'
+begin
+  require 'bundler'
+rescue LoadError
+  STDERR.puts "bundler not found - use gem install bundler to install it"
+  exit 1
+end
+
+Bundler.setup
 Bundler::GemHelper.install_tasks
 
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
 load 'rails/tasks/engine.rake'
 

--- a/spec/setup_database.rb
+++ b/spec/setup_database.rb
@@ -1,7 +1,0 @@
-config = YAML::load(IO.read(File.dirname(__FILE__) + '/database.yml'))
-ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/debug.log")
-ActiveRecord::Base.establish_connection(config[ENV['DB'] || 'sqlite'])
-
-ActiveRecord::Schema.define(:version => 1) do
-
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,29 +1,45 @@
+##
 # Configure Rails Envinronment
+##
+
 ENV["RAILS_ENV"] = "test"
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+require 'rails/test_help'
 
-require 'pry'
+##
+# Setup RSpec
+##
+
 require 'rspec/rails'
-require 'shoulda-matchers'
-
-require 'factory_girl_rspec'
-FactoryGirl.definition_file_paths = [
-    File.join(File.dirname(__FILE__), 'factories')
-]
-FactoryGirl.find_definitions
-
-ENGINE_RAILS_ROOT=File.join(File.dirname(__FILE__), '../')
-
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[File.join(ENGINE_RAILS_ROOT, "spec/support/**/*.rb")].each {|f| require f }
-
 RSpec.configure do |config|
   config.include Devise::TestHelpers, :type => :controller
-
   config.use_transactional_fixtures = true
 
-  # enable rendering of views for controller tests
-  # see http://stackoverflow.com/questions/4401539/rspec-2-how-to-render-views-by-default-for-all-controller-specs
+  # Enable rendering of views for controller tests
+  # See SOF question: http://bit.ly/sof-rspec-controller-view-rendering
   config.render_views
 end
+
+spec_root = File.expand_path('..', __FILE__)
+
+##
+# Setup FactoryGirl
+## 
+
+require 'factory_girl_rspec'
+FactoryGirl.definition_file_paths = [File.join(spec_root, 'factories')]
+FactoryGirl.find_definitions
+
+require 'shoulda-matchers'
+
+##
+# Run Migrations
+##
+
+ActiveRecord::Migrator.migrate(File.expand_path("dummy/db/migrate/", spec_root))
+
+##
+# Load supporting files
+##
+
+Dir["#{spec_root}/support/**/*.rb"].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 ##
-# Configure Rails Envinronment
+# Variables
+##
+
+spec_root = File.expand_path('..', __FILE__)
+
+##
+# Configure Rails environment
 ##
 
 ENV["RAILS_ENV"] = "test"
@@ -7,7 +13,7 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'rails/test_help'
 
 ##
-# Setup RSpec
+# Setup testing tools
 ##
 
 require 'rspec/rails'
@@ -19,12 +25,6 @@ RSpec.configure do |config|
   # See SOF question: http://bit.ly/sof-rspec-controller-view-rendering
   config.render_views
 end
-
-spec_root = File.expand_path('..', __FILE__)
-
-##
-# Setup FactoryGirl
-## 
 
 require 'factory_girl_rspec'
 FactoryGirl.definition_file_paths = [File.join(spec_root, 'factories')]


### PR DESCRIPTION
Hi,

we decided to integrate your gem in our system and along the way we hope to contribute a little. We started by adding support for auto migrating the database whenever the test suite is executed. We also removed .rvmrc and .rspec from the repository because, in our opinion, these two files only contain developer specific settings and should therefore not be tied to the entire project.

Kind regards,
the flinc dev team
