### PR TITLE
Adapt authorizations controller to be scope agnostic, refs #23

### DIFF
--- a/app/controllers/devise/oauth2_providable/authorizations_controller.rb
+++ b/app/controllers/devise/oauth2_providable/authorizations_controller.rb
@@ -34,17 +34,19 @@ module Devise
       end
 
       def authorize_endpoint(allow_approval = false)
+        models = self.devise_oauth_mapping.models
+
         Rack::OAuth2::Server::Authorize.new do |req, res|
-          @client = Client.find_by_identifier(req.client_id) || req.bad_request!
+          @client = models[:client].find_by_identifier(req.client_id) || req.bad_request!
           res.redirect_uri = req.verify_redirect_uri!(@client.redirect_uri)
           if allow_approval
             if params[:approve].present?
               case req.response_type
               when :code
-                authorization_code = current_user.authorization_codes.create!(:client => @client)
+                authorization_code = self.resource.authorization_codes.create!(:client => @client)
                 res.code = authorization_code.token
               when :token
-                access_token = current_user.access_tokens.create!(:client => @client).token
+                access_token = self.resource.access_tokens.create!(:client => @client).token
                 bearer_token = Rack::OAuth2::AccessToken::Bearer.new(:access_token => access_token)
                 res.access_token = bearer_token
                 res.uid = resource.id

--- a/app/controllers/devise/oauth2_providable/authorizations_controller.rb
+++ b/app/controllers/devise/oauth2_providable/authorizations_controller.rb
@@ -34,10 +34,10 @@ module Devise
       end
 
       def authorize_endpoint(allow_approval = false)
-        models = self.devise_oauth_mapping.models
+        mapping = self.devise_oauth_mapping
 
         Rack::OAuth2::Server::Authorize.new do |req, res|
-          @client = models[:client].find_by_identifier(req.client_id) || req.bad_request!
+          @client = mapping.client.find_by_identifier(req.client_id) || req.bad_request!
           res.redirect_uri = req.verify_redirect_uri!(@client.redirect_uri)
           if allow_approval
             if params[:approve].present?

--- a/app/controllers/devise/oauth2_providable/authorizations_controller.rb
+++ b/app/controllers/devise/oauth2_providable/authorizations_controller.rb
@@ -1,6 +1,9 @@
 module Devise
   module Oauth2Providable
     class AuthorizationsController < ApplicationController
+      # If the devise internal helpers aren't loaded in the controller then it
+      # has trouble resolving scope on the DeviseHelper module
+      include ::Devise::Controllers::InternalHelpers
       include Devise::Oauth2Providable::Controllers::Helpers
       before_filter :authenticate_scope!
 

--- a/app/controllers/devise/oauth2_providable/authorizations_controller.rb
+++ b/app/controllers/devise/oauth2_providable/authorizations_controller.rb
@@ -1,7 +1,7 @@
 module Devise
   module Oauth2Providable
     class AuthorizationsController < ApplicationController
-      include Devise::Controllers::InternalHelpers
+      include Devise::Oauth2Providable::Controllers::Helpers
       before_filter :authenticate_scope!
 
       rescue_from Rack::OAuth2::Server::Authorize::BadRequest do |e|
@@ -54,13 +54,6 @@ module Devise
             @response_type = req.response_type
           end
         end
-      end
-
-      # Authenticates the current scope and gets the current resource from the session.
-      # Taken from devise
-      def authenticate_scope!
-        send(:"authenticate_#{resource_name}!", :force => true)
-        self.resource = send(:"current_#{resource_name}")
       end
     end
   end

--- a/app/controllers/devise/oauth2_providable/tokens_controller.rb
+++ b/app/controllers/devise/oauth2_providable/tokens_controller.rb
@@ -1,10 +1,11 @@
 class Devise::Oauth2Providable::TokensController < ApplicationController
-  before_filter :authenticate_user!
+  include Devise::Oauth2Providable::Controllers::Helpers
+  before_filter :authenticate_scope!
   skip_before_filter :verify_authenticity_token, :only => :create
 
   def create
-    @refresh_token = oauth2_current_refresh_token || oauth2_current_client.refresh_tokens.create!(:user => current_user)
-    @access_token = @refresh_token.access_tokens.create!(:client => oauth2_current_client, :user => current_user)
+    @refresh_token = oauth2_current_refresh_token || oauth2_current_client.refresh_tokens.create!(:user => self.resource)
+    @access_token = @refresh_token.access_tokens.create!(:client => oauth2_current_client, :user => self.resource)
     render :json => @access_token.token_response
   end
   private

--- a/app/controllers/devise/oauth2_providable/tokens_controller.rb
+++ b/app/controllers/devise/oauth2_providable/tokens_controller.rb
@@ -1,18 +1,27 @@
-class Devise::Oauth2Providable::TokensController < ApplicationController
-  include Devise::Oauth2Providable::Controllers::Helpers
-  before_filter :authenticate_scope!
-  skip_before_filter :verify_authenticity_token, :only => :create
+module Devise
+  module Oauth2Providable
+    class TokensController < ApplicationController
+      # If the devise internal helpers aren't loaded in the controller then it
+      # has trouble resolving scope on the DeviseHelper module
+      include ::Devise::Controllers::InternalHelpers
+      include Devise::Oauth2Providable::Controllers::Helpers
 
-  def create
-    @refresh_token = oauth2_current_refresh_token || oauth2_current_client.refresh_tokens.create!(:user => self.resource)
-    @access_token = @refresh_token.access_tokens.create!(:client => oauth2_current_client, :user => self.resource)
-    render :json => @access_token.token_response
-  end
-  private
-  def oauth2_current_client
-   env[Devise::Oauth2Providable::CLIENT_ENV_REF]
-  end
-  def oauth2_current_refresh_token
-    env[Devise::Oauth2Providable::REFRESH_TOKEN_ENV_REF]
+      before_filter :authenticate_scope!
+      skip_before_filter :verify_authenticity_token, :only => :create
+
+      def create
+        @refresh_token = oauth2_current_refresh_token || oauth2_current_client.refresh_tokens.create!(:user => self.resource)
+        @access_token = @refresh_token.access_tokens.create!(:client => oauth2_current_client, :user => self.resource)
+        render :json => @access_token.token_response
+      end
+      private
+      def oauth2_current_client
+       env[Devise::Oauth2Providable::CLIENT_ENV_REF]
+      end
+      def oauth2_current_refresh_token
+        env[Devise::Oauth2Providable::REFRESH_TOKEN_ENV_REF]
+      end
+    end
   end
 end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,0 @@
-Devise::Oauth2Providable::Engine.routes.draw do
-  root :to => "authorizations#new"
-
-  resources :authorizations, :only => :create
-  match 'authorize' => 'authorizations#new'
-  resource :token, :only => :create
-end

--- a/lib/devise/oauth2_providable/controllers/helpers.rb
+++ b/lib/devise/oauth2_providable/controllers/helpers.rb
@@ -3,21 +3,13 @@ module Devise
   module Oauth2Providable
     module Controllers
       module Helpers
-        extend ActiveSupport::Concern
 
-        module ClassMethods
-          include Devise::Controllers::InternalHelpers
-          include LocalInstanceMethods
-        end
-
-        module LocalInstanceMethods
-          # Authenticates the current scope and gets the current resource from the session.
-          # Taken from devise
-          def authenticate_scope!
-            send(:"authenticate_#{resource_name}!", :force => true)
-            self.resource = send(:"current_#{resource_name}")
-          end
-        end
+				# Authenticates the current scope and gets the current resource from the session.
+				# Taken from devise
+				def authenticate_scope!
+					send(:"authenticate_#{resource_name}!", :force => true)
+					self.resource = send(:"current_#{resource_name}")
+				end
       end
     end
   end

--- a/lib/devise/oauth2_providable/controllers/helpers.rb
+++ b/lib/devise/oauth2_providable/controllers/helpers.rb
@@ -4,12 +4,15 @@ module Devise
     module Controllers
       module Helpers
 
-				# Authenticates the current scope and gets the current resource from the session.
-				# Taken from devise
-				def authenticate_scope!
-					send(:"authenticate_#{resource_name}!", :force => true)
-					self.resource = send(:"current_#{resource_name}")
-				end
+        # Authenticates the current scope and gets the current resource from the session.
+        # Taken from devise
+        def authenticate_scope!
+          send(:"authenticate_#{resource_name}!", :force => true)
+          self.resource = send(:"current_#{resource_name}")
+        end
+        def devise_oauth_mapping
+          @devise_oauth_mapping ||= request.env[Devise::Oauth2Providable::MAPPING_ENV_REF]
+        end
       end
     end
   end

--- a/lib/devise/oauth2_providable/controllers/helpers.rb
+++ b/lib/devise/oauth2_providable/controllers/helpers.rb
@@ -1,0 +1,24 @@
+
+module Devise
+  module Oauth2Providable
+    module Controllers
+      module Helpers
+        extend ActiveSupport::Concern
+
+        module ClassMethods
+          include Devise::Controllers::InternalHelpers
+          include LocalInstanceMethods
+        end
+
+        module LocalInstanceMethods
+          # Authenticates the current scope and gets the current resource from the session.
+          # Taken from devise
+          def authenticate_scope!
+            send(:"authenticate_#{resource_name}!", :force => true)
+            self.resource = send(:"current_#{resource_name}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/devise/oauth2_providable/engine.rb
+++ b/lib/devise/oauth2_providable/engine.rb
@@ -5,6 +5,7 @@ module Devise
       config.devise_oauth2_providable.access_token_expires_in       = 15.minutes
       config.devise_oauth2_providable.refresh_token_expires_in      = 1.month
       config.devise_oauth2_providable.authorization_code_expires_in = 1.minute
+      config.devise_oauth2_providable.scope_settings                = {}
 
       engine_name 'oauth2'
       isolate_namespace Devise::Oauth2Providable

--- a/lib/devise/oauth2_providable/expirable_token.rb
+++ b/lib/devise/oauth2_providable/expirable_token.rb
@@ -9,7 +9,7 @@ module Devise
       module ClassMethods
         def expires_according_to(config_name)
           cattr_accessor :default_lifetime
-          self.default_lifetime = Rails.application.config.devise_oauth2_providable[config_name]
+          self.default_lifetime = ::Rails.application.config.devise_oauth2_providable[config_name]
 
           belongs_to :user
           belongs_to :client

--- a/lib/devise/oauth2_providable/mapping.rb
+++ b/lib/devise/oauth2_providable/mapping.rb
@@ -17,7 +17,7 @@ module Devise
     #
     #   mapping.prefix
     class Mapping
-      attr_reader :scope_name, :path_prefix, :controllers
+      attr_reader :scope_name, :path_prefix, :controllers, :models
 
       class << self
         def default_controllers
@@ -26,12 +26,22 @@ module Devise
             :tokens         => "devise/oauth2_providable/tokens"
           }
         end
+
+        def default_models
+          {
+            :access_token   => 'Devise::Oauth2Providable::AccessToken',
+            :client         => 'Devise::Oauth2Providable::Client',
+            :refresh_token  => 'Devise::Oauth2Providable::RefreshToken',
+            :user           => 'User',
+          }
+        end
       end
 
       def initialize(scope_name, options = {})
         @scope_name  = (options[:scope_name] || scope_name.to_s.singularize).to_sym
         @path_prefix = options[:path_prefix]
         @controllers = self.select_controllers(options)
+        @models      = self.select_models(options)
       end
 
       # Returns the devise scope mapping object associated with this oauth endpoint
@@ -42,6 +52,16 @@ module Devise
       protected
       def select_controllers(options)
         self.class.default_controllers.merge(options[:controllers] || {})
+      end
+
+      def select_models(options)
+        models = self.class.default_models.merge(self.scope_config[:models] || {})
+
+        models.each { |key,value| models[key] = value.constantize }
+      end
+
+      def scope_config
+        ::Rails.application.config.devise_oauth2_providable.scope_settings[@scope_name] || {}
       end
     end
   end

--- a/lib/devise/oauth2_providable/mapping.rb
+++ b/lib/devise/oauth2_providable/mapping.rb
@@ -1,0 +1,48 @@
+
+module Devise
+  module Oauth2Providable
+    # Responsible for mapping oauth endpoints onto devise scopes
+    #
+    # You must declare your devise scope before 
+    #
+    #   map.devise_oauth_for :users
+    #
+    #   mapping = Devise::Oauth2Providable.mappings[:user]
+    #
+    #   mapping.scope_name #=> :user
+    #   # The name of the devise scope that this endpoint will use
+    #
+    #   mapping.devise_scope #=> Devise.mappings[:user]
+    #   # Returns the devise scope associated with this mapping
+    #
+    #   mapping.prefix
+    class Mapping
+      attr_reader :scope_name, :path_prefix, :controllers
+
+      class << self
+        def default_controllers
+          {
+            :authorizations => "devise/oauth2_providable/authorizations",
+            :tokens         => "devise/oauth2_providable/tokens"
+          }
+        end
+      end
+
+      def initialize(scope_name, options = {})
+        @scope_name  = (options[:scope_name] || scope_name.to_s.singularize).to_sym
+        @path_prefix = options[:path_prefix]
+        @controllers = self.select_controllers(options)
+      end
+
+      # Returns the devise scope mapping object associated with this oauth endpoint
+      def devise_scope
+        Devise.mappings[self.scope_name]
+      end
+
+      protected
+      def select_controllers(options)
+        self.class.default_controllers.merge(options[:controllers] || {})
+      end
+    end
+  end
+end

--- a/lib/devise/oauth2_providable/rails/routes.rb
+++ b/lib/devise/oauth2_providable/rails/routes.rb
@@ -4,7 +4,7 @@ module Devise
     module Rails
       module Routes
         def devise_oauth_for(scope, options = {})
-          mapping = Devise::Oauth2Providable.add_mapping(scope, options)
+          mapping = Devise::Oauth2Providable.mapping(scope, options)
 
           path_prefix = mapping.path_prefix
           as          = mapping.scope_name

--- a/lib/devise/oauth2_providable/rails/routes.rb
+++ b/lib/devise/oauth2_providable/rails/routes.rb
@@ -11,10 +11,12 @@ module Devise
           constraints = {}
           defaults    = {}
 
-          devise_scope mapping.scope_name do
-            scope(:as => "#{as}_oauth", :path => path_prefix) do
-              devise_oauth_authorization_routes(mapping, mapping.controllers)
-              devise_oauth_token_routes(mapping, mapping.controllers)
+          devise_scope(mapping.scope_name) do
+            devise_oauth_scope(mapping) do
+              scope(:as => "#{as}_oauth", :path => path_prefix) do
+                devise_oauth_authorization_routes(mapping, mapping.controllers)
+                devise_oauth_token_routes(mapping, mapping.controllers)
+              end
             end
           end
         end
@@ -35,6 +37,17 @@ module Devise
           controller = controllers[:tokens]
 
           resource :token, :only => :create, :controller => controller
+        end
+
+        def devise_oauth_scope(mapping)
+          constraint = lambda do |request|
+            request.env[Devise::Oauth2Providable::MAPPING_ENV_REF] = mapping
+            true
+          end
+
+          constraints(constraint) do
+            yield
+          end
         end
       end
     end

--- a/lib/devise/oauth2_providable/rails/routes.rb
+++ b/lib/devise/oauth2_providable/rails/routes.rb
@@ -1,0 +1,46 @@
+
+module Devise
+  module Oauth2Providable
+    module Rails
+      module Routes
+        def devise_oauth_for(scope, options = {})
+          mapping = Devise::Oauth2Providable.add_mapping(scope, options)
+
+          path_prefix = mapping.path_prefix
+          as          = mapping.scope_name
+          constraints = {}
+          defaults    = {}
+
+          devise_scope mapping.scope_name do
+            scope(:as => "#{as}_oauth", :path => path_prefix) do
+              devise_oauth_authorization_routes(mapping, mapping.controllers)
+              devise_oauth_token_routes(mapping, mapping.controllers)
+            end
+          end
+        end
+
+        protected
+        def devise_oauth_authorization_routes(mapping, controllers)
+          controller = controllers[:authorizations]
+
+          root :controller => controller, :action => 'new'
+
+          resources :authorizations, :only => :create,
+            :controller => controller
+
+          match 'authorize', :controller => controller, :action => 'new'
+        end
+
+        def devise_oauth_token_routes(mapping, controllers)
+          controller = controllers[:tokens]
+
+          resource :token, :only => :create, :controller => controller
+        end
+      end
+    end
+  end
+end
+
+ActionDispatch::Routing::Mapper.class_eval do
+  include Devise::Oauth2Providable::Rails::Routes
+end

--- a/lib/devise/oauth2_providable/strategies/oauth2_grant_type_strategy.rb
+++ b/lib/devise/oauth2_providable/strategies/oauth2_grant_type_strategy.rb
@@ -6,7 +6,8 @@ module Devise
       include Devise::Oauth2Providable::StrategyHelpers
 
       def valid?
-        params[:controller] == 'devise/oauth2_providable/tokens' && request.post? && params[:grant_type] == grant_type
+        return false if devise_oauth_mapping.nil?
+        params[:controller] == devise_oauth_mapping.controllers[:tokens] && request.post? && params[:grant_type] == grant_type
       end
 
       # defined by subclass
@@ -15,7 +16,7 @@ module Devise
 
       def client
         return @client if @client
-        @client = devise_oauth_mapping.models[:client].find_by_identifier_and_secret(params[:client_id], params[:client_secret])
+        @client = devise_oauth_mapping.client.find_by_identifier_and_secret(params[:client_id], params[:client_secret])
         env[Devise::Oauth2Providable::CLIENT_ENV_REF] = @client
         @client
       end

--- a/lib/devise/oauth2_providable/strategies/oauth2_providable_strategy.rb
+++ b/lib/devise/oauth2_providable/strategies/oauth2_providable_strategy.rb
@@ -3,13 +3,15 @@ require 'devise/strategies/base'
 module Devise
   module Strategies
     class Oauth2Providable < Authenticatable
+      include Devise::Oauth2Providable::StrategyHelpers
+
       def valid?
         @req = Rack::OAuth2::Server::Resource::Bearer::Request.new(env)
         @req.oauth2?
       end
       def authenticate!
         @req.setup!
-        token = Devise::Oauth2Providable::AccessToken.find_by_token @req.access_token
+        token = oauth_models[:access_token].find_by_token @req.access_token
         env[Devise::Oauth2Providable::CLIENT_ENV_REF] = token.client if token
         resource = token ? token.user : nil
         if validate(resource)

--- a/lib/devise/oauth2_providable/strategies/oauth2_providable_strategy.rb
+++ b/lib/devise/oauth2_providable/strategies/oauth2_providable_strategy.rb
@@ -11,7 +11,7 @@ module Devise
       end
       def authenticate!
         @req.setup!
-        token = oauth_models[:access_token].find_by_token @req.access_token
+        token = oauth_mapping.access_token.find_by_token @req.access_token
         env[Devise::Oauth2Providable::CLIENT_ENV_REF] = token.client if token
         resource = token ? token.user : nil
         if validate(resource)

--- a/lib/devise/oauth2_providable/strategy_helpers.rb
+++ b/lib/devise/oauth2_providable/strategy_helpers.rb
@@ -1,0 +1,15 @@
+
+module Devise
+  module Oauth2Providable
+    module StrategyHelpers
+      protected
+      def oauth_mapping
+        Devise::Oauth2Providable.mappings[mapping.name]
+      end
+
+      def oauth_models
+        self.oauth_mapping.models
+      end
+    end
+  end
+end

--- a/lib/devise/oauth2_providable/strategy_helpers.rb
+++ b/lib/devise/oauth2_providable/strategy_helpers.rb
@@ -6,10 +6,6 @@ module Devise
       def oauth_mapping
         Devise::Oauth2Providable.mappings[mapping.name]
       end
-
-      def oauth_models
-        self.oauth_mapping.models
-      end
     end
   end
 end

--- a/lib/devise_oauth2_providable.rb
+++ b/lib/devise_oauth2_providable.rb
@@ -2,6 +2,7 @@ require 'devise'
 require 'rack/oauth2'
 require 'devise/oauth2_providable/engine'
 require 'devise/oauth2_providable/expirable_token'
+require 'devise/oauth2_providable/strategy_helpers'
 require 'devise/oauth2_providable/strategies/oauth2_providable_strategy'
 require 'devise/oauth2_providable/strategies/oauth2_password_grant_type_strategy'
 require 'devise/oauth2_providable/strategies/oauth2_refresh_token_grant_type_strategy'
@@ -14,10 +15,12 @@ require 'devise/oauth2_providable/controllers/helpers'
 require 'devise/oauth2_providable/mapping'
 require 'devise/oauth2_providable/rails/routes'
 
+
 module Devise
   module Oauth2Providable
     CLIENT_ENV_REF = 'oauth2.client'
     REFRESH_TOKEN_ENV_REF = "oauth2.refresh_token"
+    MAPPING_ENV_REF = "devise_oauth2_providable.mapping"
 
     mattr_reader :mappings
     @@mappings = ActiveSupport::OrderedHash.new

--- a/lib/devise_oauth2_providable.rb
+++ b/lib/devise_oauth2_providable.rb
@@ -10,13 +10,26 @@ require 'devise/oauth2_providable/models/oauth2_providable'
 require 'devise/oauth2_providable/models/oauth2_password_grantable'
 require 'devise/oauth2_providable/models/oauth2_refresh_token_grantable'
 require 'devise/oauth2_providable/models/oauth2_authorization_code_grantable'
+require 'devise/oauth2_providable/controllers/helpers'
+require 'devise/oauth2_providable/mapping'
+require 'devise/oauth2_providable/rails/routes'
 
 module Devise
   module Oauth2Providable
     CLIENT_ENV_REF = 'oauth2.client'
     REFRESH_TOKEN_ENV_REF = "oauth2.refresh_token"
 
+    mattr_reader :mappings
+    @@mappings = ActiveSupport::OrderedHash.new
+
     class << self
+      def add_mapping(name, options)
+        mapping = Devise::Oauth2Providable::Mapping.new(name, options)
+
+        @@mappings[mapping.scope_name] = mapping
+        mapping
+      end
+
       def random_id
         SecureRandom.hex
       end

--- a/lib/devise_oauth2_providable.rb
+++ b/lib/devise_oauth2_providable.rb
@@ -26,11 +26,14 @@ module Devise
     @@mappings = ActiveSupport::OrderedHash.new
 
     class << self
-      def add_mapping(name, options)
-        mapping = Devise::Oauth2Providable::Mapping.new(name, options)
+      def mapping(name, options={})
+        scope = Mapping.scope_name(name, options)
 
-        @@mappings[mapping.scope_name] = mapping
-        mapping
+        if @@mappings.has_key?(scope)
+          @@mappings[scope].apply_options(options)
+        else
+          @@mappings[scope] = Mapping.new(name, options)
+        end
       end
 
       def random_id

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
 
   resources :protected
 
-  mount Devise::Oauth2Providable::Engine => '/oauth2'
+  devise_scope :user do
+    mount Devise::Oauth2Providable::Engine => '/oauth2'
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,7 +3,5 @@ Rails.application.routes.draw do
 
   resources :protected
 
-  devise_scope :user do
-    mount Devise::Oauth2Providable::Engine => '/oauth2'
-  end
+  devise_oauth_for :users, :path_prefix => 'oauth2'
 end

--- a/spec/lib/devise/oauth2_providable/mapping_spec.rb
+++ b/spec/lib/devise/oauth2_providable/mapping_spec.rb
@@ -4,108 +4,174 @@ describe Devise::Oauth2Providable::Mapping do
 
   let (:mapping_class) { Devise::Oauth2Providable::Mapping }
 
-  describe "devise_oauth_for" do
+  describe ".scope_name" do
+    context "when given a plural string name ('members')" do
+      subject { mapping_class.scope_name('members') }
 
-
-    describe "#scope_name" do
-      it "is the singular version of the name provided in initializer" do
-        mapping = mapping_class.new(:users)
-
-        mapping.scope_name.should == :user
-      end
-
-      it "can be overriden by the :scope_name option" do
-        mapping = mapping_class.new(:users, :scope_name => 'member')
-
-        mapping.scope_name.should == :member
-      end
+      it { subject.should be_a(Symbol) }
+      it { subject.should eql(:member) }
     end
 
-    describe "#devise_scope" do
-      let (:devise_scope) { stub() }
-      it "returns the devise mapping object" do
-        Devise.mappings.should_receive(:[]).with(:user).and_return(devise_scope)
+    context "when given a singular name as a string ('member')" do
+      subject { mapping_class.scope_name('member') }
 
-        mapping = mapping_class.new(:users)
-
-        mapping.devise_scope.should eql(devise_scope)
-      end
+      it { subject.should be_a(Symbol) }
+      it { subject.should eql(:member) }
     end
 
-    describe "#models" do
-      subject { mapping_class.new(:users) }
+    context "when given a plural name as a symbol (:members)" do
+      subject { mapping_class.scope_name(:members) }
 
-      context "when no model overrides exist for the scope" do
-        before(:each) do
-          ::Rails.application.config.
-            stub_chain(:devise_oauth2_providable, :scope_settings).
-            and_return({})
+      it { subject.should be_a(Symbol) }
+      it { subject.should eql(:member) }
+    end
+
+    context "when given a singular name as a symbol (:member)" do
+      subject {mapping_class.scope_name(:member)}
+
+      it { subject.should be_a(Symbol) }
+      it { subject.should eql(:member) }
+    end
+
+    context "when :scope_name is specified in the options hash (:members, :scope_name => 'user')" do
+      subject { mapping_class.scope_name(:members, :scope_name => 'users') }
+
+      it { subject.should be_a(Symbol) }
+      it "the scope name is set to the value without modification" do
+        subject.should eql(:users)
+      end
+    end
+  end
+
+  describe "#scope_name" do
+    it "is the singular version of the name provided in initializer" do
+      mapping = mapping_class.new(:users)
+
+      mapping.scope_name.should == :user
+    end
+
+    it "can be overriden by the :scope_name option" do
+      mapping = mapping_class.new(:users, :scope_name => 'member')
+
+      mapping.scope_name.should == :member
+    end
+  end
+
+  describe "#devise_scope" do
+    let (:devise_scope) { stub() }
+    it "returns the devise mapping object" do
+      Devise.mappings.should_receive(:[]).with(:user).and_return(devise_scope)
+
+      mapping = mapping_class.new(:users)
+
+      mapping.devise_scope.should eql(devise_scope)
+    end
+  end
+
+  context "when no model overrides are specified in the scope's config initializer" do
+
+    subject { mapping_class.new(:users) }
+    before(:each) do
+      ::Rails.application.config.
+        stub_chain(:devise_oauth2_providable, :scope_settings).
+        and_return({})
+    end
+
+    it "#models contains the default models" do
+      subject.models.should eql({
+        :access_token  => 'Devise::Oauth2Providable::AccessToken',
+        :client        => 'Devise::Oauth2Providable::Client',
+        :refresh_token => 'Devise::Oauth2Providable::RefreshToken',
+        :user          => 'User'
+      })
+    end
+
+    it "#access_token returns the AccessToken model constant" do
+      subject.access_token.should eql(Devise::Oauth2Providable::AccessToken)
+    end
+
+    it "#client returns the Client model constant" do
+      subject.client.should eql(Devise::Oauth2Providable::Client)
+    end
+
+    it "#refresh_token returns the RefreshToken model constant" do
+      subject.refresh_token.should eql(Devise::Oauth2Providable::RefreshToken)
+    end
+
+    it "#user returns the correct User model constant" do
+      subject.user.should eql(User)
+    end
+  end
+
+  context "when model overrides are specified in the scope's config initializer" do
+    class MyTotallyAwesomeUser 
+    end
+
+    subject { mapping_class.new(:users) }
+    before(:each) do
+      ::Rails.application.config.
+        stub_chain(:devise_oauth2_providable, :scope_settings).
+        and_return({:user => {:models => {:user => 'MyTotallyAwesomeUser'}}})
+    end
+
+    it "#models contains the overriden models" do
+      subject.models.should eql({
+        :access_token  => 'Devise::Oauth2Providable::AccessToken',
+        :client        => 'Devise::Oauth2Providable::Client',
+        :refresh_token => 'Devise::Oauth2Providable::RefreshToken',
+        :user          => 'MyTotallyAwesomeUser'
+      })
+    end
+
+    it "#access_token returns the AccessToken model constant" do
+      subject.access_token.should eql(Devise::Oauth2Providable::AccessToken)
+    end
+
+    it "#client returns the Client model constant" do
+      subject.client.should eql(Devise::Oauth2Providable::Client)
+    end
+
+    it "#refresh_token returns the RefreshToken model constant" do
+      subject.refresh_token.should eql(Devise::Oauth2Providable::RefreshToken)
+    end
+
+    it "#user returns the correct User model constant" do
+      subject.user.should eql(MyTotallyAwesomeUser)
+    end
+  end
+
+  describe "#path_prefix" do
+    context "is specified" do
+      subject { mapping = mapping_class.new(:users, {:path_prefix => "member"}) }
+
+      it "is set in the mapping object" do
+        subject.path_prefix.should eql("member")
+      end
+    end
+  end
+
+  describe "#controllers" do
+    context "when custom controllers are specified" do
+      context "and all the defaults are overridden" do
+        it "the custom ones are used instead of defaults" do
+          controllers = {:authorizations => "authorizations", :tokens => "tokens"}
+
+          mapping = mapping_class.new(:users, {:controllers => controllers})
+
+          mapping.controllers.should eql(controllers)
         end
+      end
 
-        it "the defaults are used" do
-          subject.models.should eql({
-            :access_token  => Devise::Oauth2Providable::AccessToken,
-            :client        => Devise::Oauth2Providable::Client,
-            :refresh_token => Devise::Oauth2Providable::RefreshToken,
-            :user          => User
+      context "and only some of the defaults are overridden" do
+        it "the custom ones should be merged with defaults" do
+          controllers = {:authorizations => "authorizations"}
+
+          mapping = mapping_class.new(:users, {:controllers => controllers})
+
+          mapping.controllers.should eql({
+            :authorizations => "authorizations",
+            :tokens         => "devise/oauth2_providable/tokens"
           })
-        end
-      end
-
-      context "when model overrides are specified" do
-        class MyTotallyAwesomeUser 
-        end
-
-        before(:each) do
-          ::Rails.application.config.
-            stub_chain(:devise_oauth2_providable, :scope_settings).
-            and_return({:user => {:models => {:user => 'MyTotallyAwesomeUser'}}})
-        end
-
-        it "uses the overrides instead" do
-          subject.models.should eql({
-            :access_token  => Devise::Oauth2Providable::AccessToken,
-            :client        => Devise::Oauth2Providable::Client,
-            :refresh_token => Devise::Oauth2Providable::RefreshToken,
-            :user          => MyTotallyAwesomeUser
-          })
-        end
-      end
-    end
-
-    describe "#path_prefix" do
-      context "is specified" do
-        subject { mapping = mapping_class.new(:users, {:path_prefix => "member"}) }
-
-        it "is set in the mapping object" do
-          subject.path_prefix.should eql("member")
-        end
-      end
-    end
-
-    describe "#controllers" do
-      context "when custom controllers are specified" do
-        context "and all the defaults are overridden" do
-          it "the custom ones are used instead of defaults" do
-            controllers = {:authorizations => "authorizations", :tokens => "tokens"}
-
-            mapping = mapping_class.new(:users, {:controllers => controllers})
-
-            mapping.controllers.should eql(controllers)
-          end
-        end
-
-        context "and only some of the defaults are overridden" do
-          it "the custom ones should be merged with defaults" do
-            controllers = {:authorizations => "authorizations"}
-
-            mapping = mapping_class.new(:users, {:controllers => controllers})
-
-            mapping.controllers.should eql({
-              :authorizations => "authorizations",
-              :tokens         => "devise/oauth2_providable/tokens"
-            })
-          end
         end
       end
     end

--- a/spec/lib/devise/oauth2_providable/mapping_spec.rb
+++ b/spec/lib/devise/oauth2_providable/mapping_spec.rb
@@ -32,6 +32,47 @@ describe Devise::Oauth2Providable::Mapping do
       end
     end
 
+    describe "#models" do
+      subject { mapping_class.new(:users) }
+
+      context "when no model overrides exist for the scope" do
+        before(:each) do
+          ::Rails.application.config.
+            stub_chain(:devise_oauth2_providable, :scope_settings).
+            and_return({})
+        end
+
+        it "the defaults are used" do
+          subject.models.should eql({
+            :access_token  => Devise::Oauth2Providable::AccessToken,
+            :client        => Devise::Oauth2Providable::Client,
+            :refresh_token => Devise::Oauth2Providable::RefreshToken,
+            :user          => User
+          })
+        end
+      end
+
+      context "when model overrides are specified" do
+        class MyTotallyAwesomeUser 
+        end
+
+        before(:each) do
+          ::Rails.application.config.
+            stub_chain(:devise_oauth2_providable, :scope_settings).
+            and_return({:user => {:models => {:user => 'MyTotallyAwesomeUser'}}})
+        end
+
+        it "uses the overrides instead" do
+          subject.models.should eql({
+            :access_token  => Devise::Oauth2Providable::AccessToken,
+            :client        => Devise::Oauth2Providable::Client,
+            :refresh_token => Devise::Oauth2Providable::RefreshToken,
+            :user          => MyTotallyAwesomeUser
+          })
+        end
+      end
+    end
+
     describe "#path_prefix" do
       context "is specified" do
         subject { mapping = mapping_class.new(:users, {:path_prefix => "member"}) }

--- a/spec/lib/devise/oauth2_providable/mapping_spec.rb
+++ b/spec/lib/devise/oauth2_providable/mapping_spec.rb
@@ -21,7 +21,7 @@ describe Devise::Oauth2Providable::Mapping do
       end
     end
 
-    describe "devise_scope" do
+    describe "#devise_scope" do
       let (:devise_scope) { stub() }
       it "returns the devise mapping object" do
         Devise.mappings.should_receive(:[]).with(:user).and_return(devise_scope)
@@ -32,7 +32,7 @@ describe Devise::Oauth2Providable::Mapping do
       end
     end
 
-    describe "path_prefix" do
+    describe "#path_prefix" do
       context "is specified" do
         subject { mapping = mapping_class.new(:users, {:path_prefix => "member"}) }
 
@@ -42,24 +42,30 @@ describe Devise::Oauth2Providable::Mapping do
       end
     end
 
-    context "when custom controllers are specified" do
-      it "the custom ones are used instead of defaults" do
-        controllers = {:authorizations => "authorizations", :tokens => "tokens"}
+    describe "#controllers" do
+      context "when custom controllers are specified" do
+        context "and all the defaults are overridden" do
+          it "the custom ones are used instead of defaults" do
+            controllers = {:authorizations => "authorizations", :tokens => "tokens"}
 
-        mapping = mapping_class.new(:users, {:controllers => controllers})
+            mapping = mapping_class.new(:users, {:controllers => controllers})
 
-        mapping.controllers.should eql(controllers)
-      end
+            mapping.controllers.should eql(controllers)
+          end
+        end
 
-      it "the custom ones should be merged with defaults" do
-        controllers = {:authorizations => "authorizations"}
+        context "and only some of the defaults are overridden" do
+          it "the custom ones should be merged with defaults" do
+            controllers = {:authorizations => "authorizations"}
 
-        mapping = mapping_class.new(:users, {:controllers => controllers})
+            mapping = mapping_class.new(:users, {:controllers => controllers})
 
-        mapping.controllers.should eql({
-          :authorizations => "authorizations",
-          :tokens         => "devise/oauth2_providable/tokens"
-        })
+            mapping.controllers.should eql({
+              :authorizations => "authorizations",
+              :tokens         => "devise/oauth2_providable/tokens"
+            })
+          end
+        end
       end
     end
   end

--- a/spec/lib/devise/oauth2_providable/mapping_spec.rb
+++ b/spec/lib/devise/oauth2_providable/mapping_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Devise::Oauth2Providable::Mapping do
+
+  let (:mapping_class) { Devise::Oauth2Providable::Mapping }
+
+  describe "devise_oauth_for" do
+
+
+    describe "#scope_name" do
+      it "is the singular version of the name provided in initializer" do
+        mapping = mapping_class.new(:users)
+
+        mapping.scope_name.should == :user
+      end
+
+      it "can be overriden by the :scope_name option" do
+        mapping = mapping_class.new(:users, :scope_name => 'member')
+
+        mapping.scope_name.should == :member
+      end
+    end
+
+    describe "devise_scope" do
+      let (:devise_scope) { stub() }
+      it "returns the devise mapping object" do
+        Devise.mappings.should_receive(:[]).with(:user).and_return(devise_scope)
+
+        mapping = mapping_class.new(:users)
+
+        mapping.devise_scope.should eql(devise_scope)
+      end
+    end
+
+    describe "path_prefix" do
+      context "is specified" do
+        subject { mapping = mapping_class.new(:users, {:path_prefix => "member"}) }
+
+        it "is set in the mapping object" do
+          subject.path_prefix.should eql("member")
+        end
+      end
+    end
+
+    context "when custom controllers are specified" do
+      it "the custom ones are used instead of defaults" do
+        controllers = {:authorizations => "authorizations", :tokens => "tokens"}
+
+        mapping = mapping_class.new(:users, {:controllers => controllers})
+
+        mapping.controllers.should eql(controllers)
+      end
+
+      it "the custom ones should be merged with defaults" do
+        controllers = {:authorizations => "authorizations"}
+
+        mapping = mapping_class.new(:users, {:controllers => controllers})
+
+        mapping.controllers.should eql({
+          :authorizations => "authorizations",
+          :tokens         => "devise/oauth2_providable/tokens"
+        })
+      end
+    end
+  end
+end

--- a/spec/lib/devise/oauth2_providable/rails/routes_spec.rb
+++ b/spec/lib/devise/oauth2_providable/rails/routes_spec.rb
@@ -19,7 +19,7 @@ describe Devise::Oauth2Providable::Rails::Routes do
     end
 
     it "creates a new mapping" do
-      devise_mod.should_receive(:add_mapping).
+      devise_mod.should_receive(:mapping).
         with(scope_name, options).
         and_return(mock_mapping)
 

--- a/spec/lib/devise/oauth2_providable/rails/routes_spec.rb
+++ b/spec/lib/devise/oauth2_providable/rails/routes_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Devise::Oauth2Providable::Rails::Routes do
+  let (:devise_mod) { Devise::Oauth2Providable }
+  describe "#devise_oauth_for" do
+
+    let(:scope_name) { :users }
+    let(:options) { {} }
+    let(:mapper) do
+      set = stub(:resources_path_names => {:new => 'new', :edit => 'edit'}).as_null_object
+      ActionDispatch::Routing::Mapper.new(set)
+    end
+    let(:mock_mapping) do
+      stub(
+        :path_prefix => '',
+        :scope_name => scope_name,
+        :controllers => Devise::Oauth2Providable::Mapping.default_controllers
+      )
+    end
+
+    it "creates a new mapping" do
+      devise_mod.should_receive(:add_mapping).
+        with(scope_name, options).
+        and_return(mock_mapping)
+
+      mapper.devise_oauth_for(scope_name)
+    end
+  end
+end

--- a/spec/lib/devise_oauth2_providable_spec.rb
+++ b/spec/lib/devise_oauth2_providable_spec.rb
@@ -5,32 +5,73 @@ describe Devise::Oauth2Providable do
     # success
   end
 
-  describe "#add_mapping" do
+  describe "#mapping" do
     let(:mock_mapping) { stub(:scope_name => scope_name) }
-    let(:scope_name) { "user" }
+    let(:scope_name) { :user }
+    let(:name) { "users" }
     let(:options) { {} }
 
     before(:each) do
-      Devise::Oauth2Providable::Mapping.
-        should_receive(:new).
-        with(scope_name, options).
-        and_return(mock_mapping)
+      Devise::Oauth2Providable.mappings.clear
     end
 
-    subject { Devise::Oauth2Providable.add_mapping(scope_name, options) }
+    context "when the mapping does not exist" do
+      before(:each) do
+        Devise::Oauth2Providable::Mapping.
+          should_receive(:new).
+          with(name, options).
+          and_return(mock_mapping)
+        Devise::Oauth2Providable::Mapping.
+          should_receive(:scope_name).
+          with(name, options).
+          and_return(scope_name)
+      end
 
-    it "allows you to add a new mapping" do
-      subject
+      subject { Devise::Oauth2Providable.mapping(name, options) }
+
+      it "creates a new mapping object with specified name and options" do
+        subject
+      end
+
+      it "assigns the new mapping object to the .mappings hash with the scope name as key" do
+        subject
+        Devise::Oauth2Providable.mappings[:user].should eql(mock_mapping)
+      end
+
+      it "returns the new mapping" do
+        subject.should eql(mock_mapping)
+      end
     end
 
-    it "returns the new mapping" do
-      subject.should eql(mock_mapping)
-    end
+    context "when the mapping already exists" do
+      let(:options) { {:a => :b} }
 
-    it "assigns the mapping to the Devise::Oauth2Providable.mapping hash using scope_name" do
-      subject
+      before(:each) do
+        mock_mapping.stub(:apply_options).and_return(mock_mapping)
+        Devise::Oauth2Providable.mappings[scope_name] = mock_mapping
+        Devise::Oauth2Providable::Mapping.
+          should_receive(:scope_name).
+          with(name, options).
+          and_return(scope_name)
+      end
 
-      Devise::Oauth2Providable.mappings[scope_name].should == mock_mapping
+      subject { Devise::Oauth2Providable.mapping(name, options) }
+
+      it "does not create a new mapping object" do
+        Devise::Oauth2Providable::Mapping.should_not_receive(:new)
+
+        subject
+      end
+
+      it "applies the passed options to the mapping" do
+        mock_mapping.should_receive(:apply_options).with(options)
+
+        subject
+      end
+
+      it "returns the mapping object" do
+        subject.should eql(mock_mapping)
+      end
     end
   end
 end

--- a/spec/lib/devise_oauth2_providable_spec.rb
+++ b/spec/lib/devise_oauth2_providable_spec.rb
@@ -4,4 +4,33 @@ describe Devise::Oauth2Providable do
   it 'should be defined' do
     # success
   end
+
+  describe "#add_mapping" do
+    let(:mock_mapping) { stub(:scope_name => scope_name) }
+    let(:scope_name) { "user" }
+    let(:options) { {} }
+
+    before(:each) do
+      Devise::Oauth2Providable::Mapping.
+        should_receive(:new).
+        with(scope_name, options).
+        and_return(mock_mapping)
+    end
+
+    subject { Devise::Oauth2Providable.add_mapping(scope_name, options) }
+
+    it "allows you to add a new mapping" do
+      subject
+    end
+
+    it "returns the new mapping" do
+      subject.should eql(mock_mapping)
+    end
+
+    it "assigns the mapping to the Devise::Oauth2Providable.mapping hash using scope_name" do
+      subject
+
+      Devise::Oauth2Providable.mappings[scope_name].should == mock_mapping
+    end
+  end
 end

--- a/spec/routing/authorizations_routing_spec.rb
+++ b/spec/routing/authorizations_routing_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe Devise::Oauth2Providable::AuthorizationsController do
-  before :all do
-    Devise::Oauth2Providable::Engine.load_engine_routes
-  end
+
   describe 'routing' do
     it 'routes POST /oauth2/authorizations' do
       post('/oauth2/authorizations').should route_to('devise/oauth2_providable/authorizations#create')

--- a/spec/routing/tokens_routing_spec.rb
+++ b/spec/routing/tokens_routing_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe Devise::Oauth2Providable::TokensController do
-  before :all do
-    Devise::Oauth2Providable::Engine.load_engine_routes
-  end
+
   describe 'routing' do
     it 'routes POST /oauth2/token' do
       post('/oauth2/token').should route_to('devise/oauth2_providable/tokens#create')


### PR DESCRIPTION
Just starting a pull request to keep track of this (not ready to merge just yet). 

Currently doesn't include tests (noticed that the routing for the authorization controller is failing in routing tests so not sure if integration test is possible) or documentation (currently need to wrap the mount in a `devise_scope`)

``` ruby
  devise_scope :member do
    mount Devise::Oauth2Providable::Engine => '/oauth2'
  end
```

This is currently a breaking change, need to make it backwards compatible.
