### PR TITLE
TokensController can be subclassed

### DIFF
--- a/lib/devise/oauth2_providable/strategies/oauth2_grant_type_strategy.rb
+++ b/lib/devise/oauth2_providable/strategies/oauth2_grant_type_strategy.rb
@@ -4,7 +4,7 @@ module Devise
   module Strategies
     class Oauth2GrantTypeStrategy < Authenticatable
       def valid?
-        params[:controller] == 'devise/oauth2_providable/tokens' && request.post? && params[:grant_type] == grant_type
+        env['action_controller.instance'].kind_of?(Devise::Oauth2Providable::TokensController) && request.post? && params[:grant_type] == grant_type
       end
 
       # defined by subclass


### PR DESCRIPTION
The Oauth2GrantType strategy currently relies on the hard-coded path to the TokensController. Subclassing this controller in order to tune some of its filter behaviors, and then mounting it manually within an app doesn't work due to this constant.

This change modifies the strategy to check the type of the ActionController instance passed through the Rack environment thereby preserving the original behavior while also allowing subclassing.
