### PR TITLE
Use via on a match command so that migrate works

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Devise::Oauth2Providable::Engine.routes.draw do
   root :to => "authorizations#new"
 
   resources :authorizations, :only => :create
-  match 'authorize' => 'authorizations#new'
+  match 'authorize' => 'authorizations#new', via: [:get,:post]
   resource :token, :only => :create
 end


### PR DESCRIPTION
Rails 4 fails on the route matcher without specific http methods specified
